### PR TITLE
enable arm64 and arm 32-bit architectures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - uses: docker/setup-buildx-action@v1
+
     - name: Build
       run: |
         curl --fail --location --silent --output bob https://function61.com/go/turbobob-latest-stable-linux-amd64 && chmod +x bob

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM ubuntu:latest
 
+# can't have default values here, otherwise they'd overwrite the buildx-supplied ones
+ARG TARGETOS
+ARG TARGETARCH
+
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y \
 	xvfb \
 	x11vnc \
@@ -36,4 +40,4 @@ ADD misc/menu.xml /etc/xdg/openbox/
 
 CMD ["/usr/local/bin/screen-server", "run"]
 
-ADD rel/screen-server_linux-amd64 /usr/local/bin/screen-server
+ADD rel/screen-server_linux-$TARGETARCH /usr/local/bin/screen-server

--- a/cmd/screen-server/osd.go
+++ b/cmd/screen-server/osd.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -47,7 +46,7 @@ func (f *firefoxOsdDriver) DisplayMessage(ctx context.Context, screen *Screen, m
 	// TODO: this is not concurrency safe at all
 	osdHtmlFilename := "/tmp/osd.html"
 
-	if err := ioutil.WriteFile(osdHtmlFilename, []byte(html), 0600); err != nil {
+	if err := os.WriteFile(osdHtmlFilename, []byte(html), 0600); err != nil {
 		return err
 	}
 	defer os.Remove(osdHtmlFilename)

--- a/cmd/screen-server/webui.go
+++ b/cmd/screen-server/webui.go
@@ -143,8 +143,9 @@ func newServerHandler(screens []*Screen, logger *log.Logger) http.Handler {
 
 func runServer(ctx context.Context, handler http.Handler) error {
 	srv := &http.Server{
-		Addr:    ":80",
-		Handler: handler,
+		Addr:              ":80",
+		Handler:           handler,
+		ReadHeaderTimeout: httputils.DefaultReadHeaderTimeout,
 	}
 
 	return httputils.CancelableServer(ctx, srv, srv.ListenAndServe)

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,18 @@
 module github.com/function61/screen-server
 
-go 1.14
+go 1.20
 
 require (
 	github.com/BurntSushi/freetype-go v0.0.0-20160129220410-b763ddbfe298 // indirect
 	github.com/BurntSushi/graphics-go v0.0.0-20160129215708-b43f31a4a966 // indirect
 	github.com/BurntSushi/xgb v0.0.0-20200324125942-20f126ea2843
 	github.com/BurntSushi/xgbutil v0.0.0-20190907113008-ad855c713046
-	github.com/function61/gokit v0.0.0-20220312130703-5e89d4b6b077
+	github.com/cubewise-code/go-mime v0.0.0-20190322015324-9c5316ef3e8e // indirect
+	github.com/function61/gokit v0.0.0-20240321114127-797a00fcb45f
 	github.com/function61/holepunch-server v0.0.0-20200305174733-9c6de8210421
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/websocket v1.4.1
-	github.com/spf13/cobra v1.0.0
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/spf13/cobra v1.6.1
+	github.com/spf13/viper v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,7 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cubewise-code/go-mime v0.0.0-20190322015324-9c5316ef3e8e/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -40,6 +41,8 @@ github.com/function61/gokit v0.0.0-20210715140145-f3b952cb0d48 h1:pQsjCOG7JhR1Xe
 github.com/function61/gokit v0.0.0-20210715140145-f3b952cb0d48/go.mod h1:nfJiV01CxBDMlVDv35jnAACc7vOBFGXlAZRILvTnD0E=
 github.com/function61/gokit v0.0.0-20220312130703-5e89d4b6b077 h1:9Wr+Wm4LkfY8XTqDLQZVYZrX0oC9Px5Nw/M8t9VXfz8=
 github.com/function61/gokit v0.0.0-20220312130703-5e89d4b6b077/go.mod h1:xXf3guLmxHiZ4iVcmo3rfeMHIotBUNAge+zswrzQoqI=
+github.com/function61/gokit v0.0.0-20240321114127-797a00fcb45f h1:meF6JJLLrZuHWtVQrQ+o2mS+oEe4Dt0MyU+to8DxUio=
+github.com/function61/gokit v0.0.0-20240321114127-797a00fcb45f/go.mod h1:sJY957+7ush4oj4ElOMhUFaFIriAFNAGYzVh2tFJNy0=
 github.com/function61/holepunch-server v0.0.0-20200305174733-9c6de8210421 h1:8yLWUK7RFUUdOxGZkLonn6ywERn33Uc4BvBJyLERnU0=
 github.com/function61/holepunch-server v0.0.0-20200305174733-9c6de8210421/go.mod h1:TG4RW9xiRLLk4p8Uy4zvkraTKIB91RyJ6WBIRDFssSM=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -72,6 +75,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
+github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -121,6 +126,7 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -131,15 +137,21 @@ github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
+github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
+github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tj/assert v0.0.3/go.mod h1:Ne6X72Q+TB1AteidzQncjw9PabbMp4PBMZ1k+vd1Pvk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
@@ -196,4 +208,7 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/turbobob.json
+++ b/turbobob.json
@@ -16,12 +16,15 @@
 		}
 	],
 	"os_arches": {
-		"linux-amd64": true
+		"linux-amd64": true,
+		"linux-arm64": true,
+		"linux-arm": true
 	},
 	"docker_images": [
 		{
 			"image": "fn61/screen-server",
-			"dockerfile_path": "Dockerfile"
+			"dockerfile_path": "Dockerfile",
+			"platforms": ["linux/amd64", "linux/arm64", "linux/arm/v7"]
 		}
 	]
 }

--- a/turbobob.json
+++ b/turbobob.json
@@ -6,7 +6,7 @@
 	"builders": [
 		{
 			"name": "default",
-			"uses": "docker://fn61/buildkit-golang:20220115_1318_71191646",
+			"uses": "docker://fn61/buildkit-golang:20240405_0714_856c11bd",
 			"mount_destination": "/workspace",
 			"workdir": "/workspace",
 			"commands": {


### PR DESCRIPTION
First multi-arch image, non-amd64 ones are **not tested** by me: https://hub.docker.com/layers/fn61/screen-server/20240413_1545_2f44336a/images/sha256-15098838b5dfc9be6feb508c0373d7fe9da97647fd507b878cd84976b0befcd7?context=explore

**UPDATE**: this version was bad

Please comment if these work for you, would encourage me to do a merge.